### PR TITLE
fixed a bug where cacheFirst tried to use cacheOnly

### DIFF
--- a/src/gridsome.server.ts
+++ b/src/gridsome.server.ts
@@ -221,7 +221,7 @@ class GridsomePluginServiceWorker {
 							return ${fileTypesCode}.includes(request.destination);
 						}
 					},
-					cacheOnly
+					cacheFirst
 				);`;
 			}
 


### PR DESCRIPTION
This should fix #10 where using cacheFirst would generate an error that cacheOnly is not defined.

It seems some code from addCacheOnlyToServiceWorkerContent() was copied into the cacheFirst version without changing it.